### PR TITLE
patch: add download progress, custom config and fix command processing

### DIFF
--- a/packages/afrim-input/package.json
+++ b/packages/afrim-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afrim-input",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A library that simplify the deployment of Afrim in any text field.",
   "main": "dist/afrim_input.js",
   "types": "dist/afrim_input.d.ts",

--- a/packages/afrim-input/src/config.ts
+++ b/packages/afrim-input/src/config.ts
@@ -12,8 +12,8 @@ export class AfrimConfig {
   constructor() {}
 
   // Load the configuration file from an URL.
-  async loadFromUrl(configUrl: string) {
-    const data = await httpGet(configUrl);
+  async loadFromUrl(configUrl: string, downloadStatusElement: HTMLElement) {
+    const data = await httpGet(configUrl, downloadStatusElement);
     const content = await tomlToJson(data);
     let auto_capitalize = false;
 
@@ -30,7 +30,10 @@ export class AfrimConfig {
         if (typeof value == "string") {
           this.translation[key] = [value];
         } else if (value.has("path")) {
-          await this.loadFromUrl(new URL(value.get("path"), configUrl).href);
+          await this.loadFromUrl(
+            new URL(value.get("path"), configUrl).href,
+            downloadStatusElement,
+          );
         } else if (value.has("alias")) {
           let data = null;
 
@@ -59,7 +62,10 @@ export class AfrimConfig {
         if (typeof value == "string") {
           this.data[key] = value;
         } else if (value.has("path")) {
-          await this.loadFromUrl(new URL(value.get("path"), configUrl).href);
+          await this.loadFromUrl(
+            new URL(value.get("path"), configUrl).href,
+            downloadStatusElement,
+          );
         } else if (value.has("alias")) {
           const data = value.get("value");
           for (const alias of value.get("alias")) {
@@ -86,7 +92,10 @@ export class AfrimConfig {
       for (const translator of content.get("translators")) {
         const key = translator[0];
         const value = translator[1];
-        const data = await httpGet(new URL(value, configUrl).href);
+        const data = await httpGet(
+          new URL(value, configUrl).href,
+          downloadStatusElement,
+        );
 
         this.translators[key] = data;
       }

--- a/packages/afrim-input/src/index.ts
+++ b/packages/afrim-input/src/index.ts
@@ -136,9 +136,6 @@ export default class AfrimInput {
         this.listenMouse();
         this.listenTextFieldState();
 
-        // We start the processor.
-        this.processCommand();
-
         // We mark the text field available.
         this.textFieldElement.disabled = false;
         this.downloadStatusElement.hidden = true;
@@ -224,56 +221,58 @@ export default class AfrimInput {
     );
   }
 
-  // We execute preprocessor commands in IDLE.
-  private processCommand() {
+  // We execute preprocessor commands.
+  private processCommand(): boolean {
     const cmd = this.preprocessor?.popQueue();
     const textValue = this.textFieldElement.value;
 
     this.data.cursorPos = this.data.cursorPos < 0 ? 0 : this.data.cursorPos;
 
-    if (cmd) {
-      if (cmd.Delete != undefined) {
-        let step = cmd.Delete.length ?? 1;
-        step -= this.data.isBackspacePressed ? 1 : 0;
-        this.data.isBackspacePressed = false;
-        this.textFieldElement.value =
-          textValue.substring(0, this.data.cursorPos - step) +
-          textValue.substring(this.data.cursorPos, textValue.length);
-        this.data.cursorPos -= step;
-        this.restoreCursorPosition();
-      } else if (cmd == "Pause") {
-        this.data.isIdle = true;
-      } else if (cmd == "Resume") {
-        this.data.isIdle = false;
-      } else if (cmd == "NOP") {
-      } else if (cmd.CommitText) {
-        this.textFieldElement.value =
-          textValue.substring(0, this.data.cursorPos) +
-          cmd.CommitText +
-          textValue.substring(this.data.cursorPos, textValue.length);
-        this.data.cursorPos += cmd.CommitText.length;
-        this.restoreCursorPosition();
-      } else {
-        if (process.env.NODE_ENV !== "production") {
-          console.error(`afrim command "${cmd}" unsupported.`);
-        }
+    if (!cmd) {
+      return false;
+    }
+
+    if (cmd.Delete != undefined) {
+      let step = cmd.Delete.length ?? 1;
+      step -= this.data.isBackspacePressed ? 1 : 0;
+      this.data.isBackspacePressed = false;
+      this.textFieldElement.value =
+        textValue.substring(0, this.data.cursorPos - step) +
+        textValue.substring(this.data.cursorPos, textValue.length);
+      this.data.cursorPos -= step;
+      this.restoreCursorPosition();
+    } else if (cmd == "Pause") {
+      this.data.isIdle = true;
+    } else if (cmd == "Resume") {
+      this.data.isIdle = false;
+    } else if (cmd == "NOP") {
+    } else if (cmd.CommitText) {
+      this.textFieldElement.value =
+        textValue.substring(0, this.data.cursorPos) +
+        cmd.CommitText +
+        textValue.substring(this.data.cursorPos, textValue.length);
+      this.data.cursorPos += cmd.CommitText.length;
+      this.restoreCursorPosition();
+    } else {
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`afrim command "${cmd}" unsupported.`);
       }
     }
 
-    this.animation = requestAnimationFrame(() => this.processCommand());
+    return cmd != "NOP";
   }
 
   private async loadConfigFromUrl(configUrl: string) {
     // We download the datalang.
     let afrimConfig = new AfrimConfig();
-    await afrimConfig.loadFromUrl(configUrl);
+    await afrimConfig.loadFromUrl(configUrl, this.downloadStatusElement);
 
     return afrimConfig;
   }
 
   // We config the afrim ime.
   private async initAfrim(config: AfrimConfig) {
-    const afrim = await require("afrim");
+    const afrim = await import("afrim");
 
     this.preprocessor = new afrim.Preprocessor(config.data, 64);
     this.translator = new afrim.Translator(config.translation, false, 0.7);
@@ -320,8 +319,6 @@ export default class AfrimInput {
           ) {
             this.data.isIdle = !this.data.isIdle;
           }
-
-          return;
         }
 
         if (event.key == "GroupPrevious" || event.key == "GroupNext") return;
@@ -333,6 +330,8 @@ export default class AfrimInput {
 
         const changed = this.preprocessor?.process(event.key, "keydown");
         const input = this.preprocessor?.getInput() || "";
+
+        while (this.processCommand());
 
         // We update the predicates if input changed.
         if (!changed) return;

--- a/packages/afrim-input/src/index.ts
+++ b/packages/afrim-input/src/index.ts
@@ -331,6 +331,7 @@ export default class AfrimInput {
         const changed = this.preprocessor?.process(event.key, "keydown");
         const input = this.preprocessor?.getInput() || "";
 
+	// Process pending commands.
         while (this.processCommand());
 
         // We update the predicates if input changed.

--- a/packages/afrim-input/src/index.ts
+++ b/packages/afrim-input/src/index.ts
@@ -331,7 +331,7 @@ export default class AfrimInput {
         const changed = this.preprocessor?.process(event.key, "keydown");
         const input = this.preprocessor?.getInput() || "";
 
-	// Process pending commands.
+        // Process pending commands.
         while (this.processCommand());
 
         // We update the predicates if input changed.

--- a/packages/afrim-input/src/utils.ts
+++ b/packages/afrim-input/src/utils.ts
@@ -4,15 +4,19 @@ import ky from "ky";
 
 // Convert TOML to JSON.
 export async function tomlToJson(data: string) {
-  const afrim = await require("afrim");
+  const afrim = await import("afrim");
 
   return afrim.convertTomlToJson(data);
 }
 
 // Make a http get request.
 // HTTP because we want a fast request.
-export async function httpGet(url: string) {
-  const response = await ky(url);
+export async function httpGet(url: string, downloadStatusElement: HTMLElement) {
+  const response = await ky(url, {
+    onDownloadProgress: (progress, chunk) => {
+      downloadStatusElement.textContent = `${url} | ${progress.percent * 100}% - ${progress.transferredBytes} of ${progress.totalBytes} bytes`;
+    },
+  });
 
   if (!response.ok) throw new Error(`Fetch error: ${response.statusText}`);
 

--- a/packages/afrim-playground/src/index.html
+++ b/packages/afrim-playground/src/index.html
@@ -135,6 +135,13 @@
               </tr>
             </tbody>
           </table>
+          <br />
+          <h1 class="title">How to use a custom dataset</h1>
+          <hr />
+          <span
+            >Use the url param configUrl. eg:
+            ?configUrl=https://raw.githubusercontent.com/fodydev/afrim-data/7584bc34cce93f8c52533065899d49acb42bd6d0/am/am.toml</span
+          >
         </div>
       </div>
       <!-- Hero footer: will stick at the bottom -->
@@ -229,6 +236,26 @@
           fmp: "Nufi",
           gez: "Geez",
         });
+
+        // Set the language if default configutation url.
+        var selectedLang;
+        if ((selectedLang = window.location.search.match(/lang=(\w*)/))) {
+          selectedLang = selectedLang[1];
+        } else if ((selectedLang = sessionStorage.getItem("lang"))) {
+        } else {
+          selectedLang = langData[0][0];
+        }
+        sessionStorage.setItem("lang", selectedLang);
+
+        // Set the configuration url.
+        var configUrl;
+        if ((configUrl = window.location.search.match(/configUrl=(.*)/))) {
+          configUrl = configUrl[1];
+        } else {
+          configUrl = `https://raw.githubusercontent.com/fodydev/afrim-data/4b177197bb37c9742cd90627b1ad543c32ec791b/${selectedLang}/${selectedLang}.toml`;
+        }
+
+        // Display language lists.
         const langListElement = document.getElementById("lang-list");
         const langHTML = langListElement.innerHTML;
 
@@ -236,24 +263,17 @@
 
         for (const lang of langData) {
           const langItem = document.createElement("a");
-          langItem.className = "navbar-item";
+          langItem.classList.add("navbar-item");
+          if (lang[0] === selectedLang) {
+            langItem.classList.add("is-active");
+          }
+
           langItem.id = lang[0];
           langItem.onclick = function () {
             window.location.search = `?lang=${lang[0]}`;
           };
           langItem.textContent = lang[1];
           langListElement.appendChild(langItem);
-        }
-
-        // Set the language.
-        var lang = window.location.search.match(/lang=(\w*)/);
-        lang = lang ? lang[1] : null;
-        var lang = lang ?? sessionStorage.getItem("lang");
-        if (lang != null && langData.find((e) => e[0] == lang)) {
-          sessionStorage.setItem("lang", lang);
-        } else {
-          lang = langData[0][0];
-          sessionStorage.setItem("lang", lang);
         }
 
         // Wait the afrim to be available.
@@ -263,7 +283,7 @@
           tooltipElementID: "tooltip",
           tooltipInputElementID: "tooltip-input",
           tooltipPredicatesElementID: "tooltip-predicates",
-          configUrl: `https://raw.githubusercontent.com/fodydev/afrim-data/4b177197bb37c9742cd90627b1ad543c32ec791b/${lang}/${lang}.toml`,
+          configUrl: configUrl,
           tooltipAdjustLeft: 25,
           tooltipAdjustTop: 125,
         });

--- a/packages/afrim-playground/src/index.html
+++ b/packages/afrim-playground/src/index.html
@@ -251,6 +251,7 @@
         var configUrl;
         if ((configUrl = window.location.search.match(/configUrl=(.*)/))) {
           configUrl = configUrl[1];
+          selectedLang = null;
         } else {
           configUrl = `https://raw.githubusercontent.com/fodydev/afrim-data/4b177197bb37c9742cd90627b1ad543c32ec791b/${selectedLang}/${selectedLang}.toml`;
         }


### PR DESCRIPTION
### Related issues

- close #44 

### Change

- display downloading progress of datasets
- execute preprocessor commands in once after each key input instead of one per frame loop
- add the param `configUrl` to facilitate the loading of custom datasets by the user
- increase the minor version of `afrim-input` for a release.

### Minor changes

- replaced `require` by `import` to import the afrim WASM dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live download progress updates during configuration, translation, and dataset loading.
  * Added help text for using a custom dataset via the `configUrl` URL parameter.
  * When a custom `configUrl` is provided, it takes precedence over language selection.

* **Bug Fixes**
  * Improved queued command handling in the input field to ensure pending commands are fully processed.
  * Refined language menu rendering/state when switching languages.

* **Chores**
  * Bumped the `afrim-input` package version to `0.1.6`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->