### PR TITLE
chore: set geez as default language

### DIFF
--- a/packages/afrim-playground/src/index.html
+++ b/packages/afrim-playground/src/index.html
@@ -243,7 +243,7 @@
           selectedLang = selectedLang[1];
         } else if ((selectedLang = sessionStorage.getItem("lang"))) {
         } else {
-          selectedLang = langData[0][0];
+          selectedLang = 'gez';
         }
         sessionStorage.setItem("lang", selectedLang);
 

--- a/packages/afrim-playground/src/index.html
+++ b/packages/afrim-playground/src/index.html
@@ -243,7 +243,7 @@
           selectedLang = selectedLang[1];
         } else if ((selectedLang = sessionStorage.getItem("lang"))) {
         } else {
-          selectedLang = 'gez';
+          selectedLang = "gez";
         }
         sessionStorage.setItem("lang", selectedLang);
 


### PR DESCRIPTION
### Change

- set geez by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default language selection to Ge’ez when no language preference is specified.
  * Preserved existing language menu behavior for stored or URL-provided preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->